### PR TITLE
fix(deps): bump pyromark from `==0.6.0` to `~=0.6.0`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 jinja2
 livereload
 toposort
-pyromark==0.6.0
+pyromark~=0.6.0
 python-frontmatter
 requests
 progress


### PR DESCRIPTION
Hi, pyromark developer here. First of all, thanks for using pyromark in your project. I created this PR as it is safe to pin pyromark to `>=0.6,<0.7` as there will be no breaking changes between these releases.