### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,6 @@
 name: Publish documentation
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/capjamesg/aurora/security/code-scanning/7](https://github.com/capjamesg/aurora/security/code-scanning/7)

To fix the issue, we should add a permissions block with minimal required privileges. Since the workflow only needs to check out code from the repository (with `actions/checkout`), the minimal required permission is `'contents: read'`. This can be set either at the workflow root or at the job level. It's common to place it at the top level to ensure all jobs inherit it unless otherwise specified. The addition should be right after the workflow `name:` line and before the `on:` block, or just after. No new imports, methods, or other code changes are required—just YAML configuration.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
